### PR TITLE
Fixes

### DIFF
--- a/BelcoShopware/src/Resources/config/services.xml
+++ b/BelcoShopware/src/Resources/config/services.xml
@@ -10,6 +10,7 @@
             <argument id="Shopware\Core\Checkout\Cart\SalesChannel\CartService" type="service"/>
             <argument id="Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface" type="service"/>
             <argument id="order.repository" type="service"/>
+            <argument type="service" id="Psr\Log\LoggerInterface" />
             <tag name="kernel.event_subscriber"/>
         </service>
     </services>

--- a/BelcoShopware/src/Resources/views/storefront/base.html.twig
+++ b/BelcoShopware/src/Resources/views/storefront/base.html.twig
@@ -1,12 +1,15 @@
-{% sw_extends '@Storefront/storefront/layout/footer/footer.html.twig' %}
+{% sw_extends '@Storefront/storefront/base.html.twig' %}
 
-{% block layout_footer_navigation_columns %}
+{% block base_body_script %}
     {{ parent() }}
 
     {% if(page.footer.shopId) %}
         <script>window.belcoConfig = {{ page.footer.belcoConfig|raw }};</script>
+    {% else %}
+        <script>
+            console.log("Belco config is not set, script not injected");
+        </script>
     {% endif %}
-
     <script>
         !function(n,o){var e=window.belcoFunction||"Belco";window[e]||(window[e]=function(n){if(void 0===window[e][n])throw new Error("Unknown method");return window[e][n].apply(window[e],Array.prototype.slice.call(arguments,1))}),window[e]._q=[];for(var i=["init","sync","track","page","open","close","toggle","on","once","off","anonymousId","customer","reset","sendMessage"],t=function(n){return function(){var o=Array.prototype.slice.call(arguments);return o.unshift(n),window[e]._q.push(o),window[e]}},w=0;w<i.length;w++){var r=i[w];window[e][r]=t(r)}window[e].load=function(e){if(!n.getElementById("belco-js")){var i=n.createElement(o);i.async=!0,i.id="belco-js",i.type="text/javascript",i.src="//cdn.belco.io/v2/widget.js",i.onload=function(n){"function"==typeof e&&e(n)};var t=n.getElementsByTagName(o)[0];t.parentNode.insertBefore(i,t)}},window.belcoConfig&&window[e].load(function(){window[e]("init",window.belcoConfig)})}(document,"script");
     </script>

--- a/BelcoShopware/src/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/BelcoShopware/src/Resources/views/storefront/layout/footer/footer.html.twig
@@ -1,16 +1,13 @@
 {% sw_extends '@Storefront/storefront/layout/footer/footer.html.twig' %}
 
-{% block layout_footer_navigation_columns  %}
+{% block base_body_script %}
     {{ parent() }}
 
     {% if(page.footer.shopId) %}
-
-            <script>window.belcoConfig = {{ page.footer.belcoConfig|raw }};</script>
-
+        <script>window.belcoConfig = {{ page.footer.belcoConfig|raw }};</script>
     {% endif %}
 
     <script>
         !function(n,o){var e=window.belcoFunction||"Belco";window[e]||(window[e]=function(n){if(void 0===window[e][n])throw new Error("Unknown method");return window[e][n].apply(window[e],Array.prototype.slice.call(arguments,1))}),window[e]._q=[];for(var i=["init","sync","track","page","open","close","toggle","on","once","off","anonymousId","customer","reset","sendMessage"],t=function(n){return function(){var o=Array.prototype.slice.call(arguments);return o.unshift(n),window[e]._q.push(o),window[e]}},w=0;w<i.length;w++){var r=i[w];window[e][r]=t(r)}window[e].load=function(e){if(!n.getElementById("belco-js")){var i=n.createElement(o);i.async=!0,i.id="belco-js",i.type="text/javascript",i.src="//cdn.belco.io/v2/widget.js",i.onload=function(n){"function"==typeof e&&e(n)};var t=n.getElementsByTagName(o)[0];t.parentNode.insertBefore(i,t)}},window.belcoConfig&&window[e].load(function(){window[e]("init",window.belcoConfig)})}(document,"script");
     </script>
-
 {% endblock %}

--- a/BelcoShopware/src/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/BelcoShopware/src/Resources/views/storefront/layout/footer/footer.html.twig
@@ -1,6 +1,6 @@
 {% sw_extends '@Storefront/storefront/layout/footer/footer.html.twig' %}
 
-{% block base_body_script %}
+{% block layout_footer_navigation_columns %}
     {{ parent() }}
 
     {% if(page.footer.shopId) %}

--- a/BelcoShopware/src/Storefront/Subscriber/BelcoSubscriber.php
+++ b/BelcoShopware/src/Storefront/Subscriber/BelcoSubscriber.php
@@ -107,19 +107,21 @@ class BelcoSubscriber implements EventSubscriberInterface
         $items = [];
         foreach ($cart->getLineItems()->getElements() as $item) {
             //ID is a Hexadecimal value, but needs to be a long. Since this ID isn't used (until now) it is changed to 0
-            $items[] = array(
+            $items[] = [
                 'id'=>0,
                 'name' => $item->getLabel(),
                 'price' => (float)$item->getPrice()->getUnitPrice(),
                 'url' => $this->getProductUrl($context, $item),
-                'quantity' => (int)$item->getQuantity());
+                'quantity' => (int)$item->getQuantity()
+            ];
         }
-        return array(
+
+        return [
             'total' => (float)$cart->getPrice()->getTotalPrice(),
             'subtotal' => (float)$cart->getPrice()->getNetPrice(),
             'currency' => $context->getCurrency()->getIsoCode(),
             'items' => $items,
-        );
+        ];
     }
 
     /**
@@ -131,16 +133,16 @@ class BelcoSubscriber implements EventSubscriberInterface
         $customer = array();
 
         if ($context->getCustomer() != null) {
-
             $user = $context->getCustomer();
-            $customer = array(
+
+            $customer = [
                 'id' => $user->getId(),
                 'firstName' => $user->getFirstName(),
                 'lastName' => $user->getLastName(),
                 'email' => $user->getEmail(),
                 'country' => $context->getCurrency()->getIsoCode(),
                 'signedUp' => ($user->getFirstLogin())
-            );
+            ];
 
             if ($context->getCustomer()->getDefaultBillingAddress()->getPhoneNumber() != null) {
                 $customer['phoneNumber'] = $context->getCustomer()->getDefaultBillingAddress()->getPhoneNumber();
@@ -183,12 +185,13 @@ class BelcoSubscriber implements EventSubscriberInterface
                 $lastOrder = strtotime($aggregations->get('lastOrder')->getVars()['max']);
             }
 
-            return array(
+            return [
                 'totalSpent' => (float)$aggregations->get('totalSpent')->getVars()['sum'],
                 'lastOrder' => $lastOrder,
-                'orderCount' => (int)$aggregations->get('orderCount')->getVars()['count']
-            );
+                'orderCount' => (int)$aggregations->get('orderCount')->getVars()['count'],
+            ];
         }
+
         return null;
     }
 
@@ -201,28 +204,32 @@ class BelcoSubscriber implements EventSubscriberInterface
     {
         $customer = $this->getCustomer($salesContext);
 
-        $belcoConfig = array(
-            'shopId' => $this->getConfig()['shopId'],
+        $config = $this->getConfig($salesContext->getSalesChannelId());
+
+        $belcoConfig = [
+            'shopId' => $config['shopId'],
             'cart' => $this->getCart($salesContext)
-        );
-//        dd($belcoConfig);
+        ];
+
         if ($customer) {
             $belcoConfig = array_merge($belcoConfig, $customer);
             $order = $this->getOrderData($context, $customer['id']);
+
             if ($order != null) {
                 $belcoConfig = array_merge($belcoConfig, $order);
             }
-            if ($this->getConfig()['apiSecret']) {
-                $belcoConfig['hash'] = hash_hmac('sha256', $customer['id'], $this->getConfig()['apiSecret']);
+
+            if ($config['apiSecret']) {
+                $belcoConfig['hash'] = hash_hmac('sha256', $customer['id'], $config['apiSecret']);
             }
         }
 
         return json_encode($belcoConfig);
     }
 
-    private function getConfig(): ?array
+    private function getConfig(string $salesChannelId): array
     {
-        return $this->systemConfigService->get('BelcoShopware.config');
+        return $this->systemConfigService->get('BelcoShopware.config', $salesChannelId);
     }
 
     /**
@@ -230,25 +237,30 @@ class BelcoSubscriber implements EventSubscriberInterface
      */
     public function onPostDispatch(FooterPageletLoadedEvent $event): void
     {
-        if (!$this->getConfig()['shopId']) {
+        $salesContext = $event->getSalesChannelContext();
+
+        $config = $this->getConfig($salesContext->getSalesChannelId());
+
+        if (!$config['shopId']) {
             return;
         }
-        $salesContext = $event->getSalesChannelContext();
+
         $context = $event->getContext();
         $pagelet = $event->getPagelet();
 
-        $shopId = $this->getConfig()['shopId'];
+        $shopId = $config['shopId'];
 
-        if (!$this->getConfig()['shopId']||!$this->getConfig()['apiSecret']||!$this->getConfig()['domainName']) {
+        if (!$config['shopId']||!$config['apiSecret']||!$config['domainName']) {
             return;
         }
 
         $belcoConfig = $this->getWidgetConfig($salesContext, $context);
 
-        $optionsConfig = array(
+        $optionsConfig = [
             'belcoConfig' => $belcoConfig,
             'shopId' => $shopId
-        );
+        ];
+
         $pagelet->assign($optionsConfig);
     }
 
@@ -261,7 +273,7 @@ class BelcoSubscriber implements EventSubscriberInterface
     {
         return $this->seoUrl->replace(
             $this->seoUrl->generate('frontend.detail.page', ['productId' => $item->getId()]),
-            $this->getConfig()['domainName'],
+            $this->getConfig($context->getSalesChannelId())['domainName'],
             $context);
     }
 }

--- a/BelcoShopware/src/Storefront/Subscriber/BelcoSubscriber.php
+++ b/BelcoShopware/src/Storefront/Subscriber/BelcoSubscriber.php
@@ -229,7 +229,9 @@ class BelcoSubscriber implements EventSubscriberInterface
 
     private function getConfig(string $salesChannelId): array
     {
-        return $this->systemConfigService->get('BelcoShopware.config', $salesChannelId);
+        $config = $this->systemConfigService->get('BelcoShopware.config', $salesChannelId);
+
+        return $config ?? [];
     }
 
     /**
@@ -241,7 +243,23 @@ class BelcoSubscriber implements EventSubscriberInterface
 
         $config = $this->getConfig($salesContext->getSalesChannelId());
 
-        if (!$config['shopId']) {
+        if (!isset($config['shopId'])) {
+            echo 'shopId is not set in the configuration.' . PHP_EOL;
+
+            return;
+        }
+
+
+        if (!isset($config['apiSecret'])) {
+            echo 'apiSecret is not set in the configuration.' . PHP_EOL;
+
+            return;
+        }
+
+
+        if (!isset($config['domainName'])) {
+            echo 'domainName is not set in the configuration.' . PHP_EOL;
+
             return;
         }
 
@@ -249,10 +267,6 @@ class BelcoSubscriber implements EventSubscriberInterface
         $pagelet = $event->getPagelet();
 
         $shopId = $config['shopId'];
-
-        if (!$config['shopId']||!$config['apiSecret']||!$config['domainName']) {
-            return;
-        }
 
         $belcoConfig = $this->getWidgetConfig($salesContext, $context);
 

--- a/BelcoShopware/src/Storefront/Subscriber/BelcoSubscriber.php
+++ b/BelcoShopware/src/Storefront/Subscriber/BelcoSubscriber.php
@@ -220,11 +220,10 @@ class BelcoSubscriber implements EventSubscriberInterface
         return json_encode($belcoConfig);
     }
 
-    private function getConfig(): array
+    private function getConfig(): ?array
     {
         return $this->systemConfigService->get('BelcoShopware.config');
     }
-
 
     /**
      * @param FooterPageletLoadedEvent $event


### PR DESCRIPTION
- Make sure the correct block is used to inject the JS
- Fix: When the plugin is installed and there is no config, the subscriber breaks on (Uncaught Error: BelcoShopware\Storefront\Subscriber\BelcoSubscriber::getConfig(): Return value must be of type array, null returned)
- Make sure the config-service gets the correct settings per sales channel